### PR TITLE
Add GitHub Workflows for testing and deploying to `dev` and `main` servers

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,9 +30,9 @@ jobs:
             StrictHostKeyChecking no
           END
         env:
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SSH_IP: ${{ secrets.SSH_IP }}
+          SSH_USER: ${{ secrets.DEV_SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
+          SSH_IP: ${{ secrets.DEV_SSH_IP }}
 
       - name: Fetch latest commit
         run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }} && git fetch && git reset origin/dev --hard'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      environment: development
+      environment: dev
   deploy:
     name: Deploy to VPS
     needs: test
@@ -51,8 +51,8 @@ jobs:
 
       - name: Send Discord message on success
         if: ${{ success() }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚀 Deployment Successful"
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚀 Deployment to \`dev\` VPS successful"
 
       - name: Send Discord message on failure
         if: ${{ failure() }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚨 Deployment to VPS Failed"
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚨 Deployment to \`dev\` VPS failed"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,58 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Tests
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+    with:
+      environment: development
+  deploy:
+    name: Deploy to VPS
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy-key.pem
+          chmod 600 ~/.ssh/deploy-key.pem
+          cat >> ~/.ssh/config <<END
+          Host my-vps
+            HostName $SSH_IP
+            User $SSH_USER
+            IdentityFile ~/.ssh/deploy-key.pem
+            StrictHostKeyChecking no
+          END
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_IP: ${{ secrets.SSH_IP }}
+
+      - name: Fetch latest commit
+        run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }} && git fetch && git reset origin/dev --hard'
+
+      - name: Deploy server
+        run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }}/backend-dashboard-2/ && ./redeploy.sh'
+
+      - name: Retrieve server status
+        run: ssh my-vps 'ps a | grep puma | grep -v grep'
+
+      - name: Deploy client
+        run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }}/client/ && ./redeploy.sh'
+
+      - name: Retrieve client status
+        run: ssh my-vps 'ps a | grep http-server | grep -v grep'
+
+      - name: Send Discord message on success
+        if: ${{ success() }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚀 Deployment Successful"
+
+      - name: Send Discord message on failure
+        if: ${{ failure() }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚨 Deployment to VPS Failed"

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -30,9 +30,9 @@ jobs:
             StrictHostKeyChecking no
           END
         env:
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SSH_IP: ${{ secrets.SSH_IP }}
+          SSH_USER: ${{ secrets.MAIN_SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.MAIN_SSH_PRIVATE_KEY }}
+          SSH_IP: ${{ secrets.MAIN_SSH_IP }}
 
       - name: Fetch latest commit
         run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }} && git fetch && git reset origin/main --hard'

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      environment: production
+      environment: main
   deploy:
     name: Deploy to VPS
     needs: test
@@ -51,8 +51,8 @@ jobs:
 
       - name: Send Discord message on success
         if: ${{ success() }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚀 Deployment Successful"
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚀 Deployment to \`main\` VPS successful"
 
       - name: Send Discord message on failure
         if: ${{ failure() }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚨 Deployment to VPS Failed"
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚨 Deployment to \`main\` VPS failed"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,58 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Tests
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+    with:
+      environment: production
+  deploy:
+    name: Deploy to VPS
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy-key.pem
+          chmod 600 ~/.ssh/deploy-key.pem
+          cat >> ~/.ssh/config <<END
+          Host my-vps
+            HostName $SSH_IP
+            User $SSH_USER
+            IdentityFile ~/.ssh/deploy-key.pem
+            StrictHostKeyChecking no
+          END
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_IP: ${{ secrets.SSH_IP }}
+
+      - name: Fetch latest commit
+        run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }} && git fetch && git reset origin/main --hard'
+
+      - name: Deploy server
+        run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }}/backend-dashboard-2/ && ./redeploy.sh'
+
+      - name: Retrieve server status
+        run: ssh my-vps 'ps a | grep puma | grep -v grep'
+
+      - name: Deploy client
+        run: ssh my-vps 'cd ${{ secrets.PROJECT_ROOT }}/client/ && ./redeploy.sh'
+
+      - name: Retrieve client status
+        run: ssh my-vps 'ps a | grep http-server | grep -v grep'
+
+      - name: Send Discord message on success
+        if: ${{ success() }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚀 Deployment Successful"
+
+      - name: Send Discord message on failure
+        if: ${{ failure() }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=🚨 Deployment to VPS Failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Use client directory
-        run: cd client/
-
       # Add React test suite setup
 
       - name: Run tests
-        run: ./run_test.sh
+        run: cd client/ && ./run_test.sh
 
       - name: Send Discord message on failure
         if: ${{ failure() && ( inputs.environment == 'dev' || inputs.environment == 'main' ) }}
@@ -37,13 +34,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Use client directory
-        run: cd backend-dashboard-2/
-
       # Add Rails test suite setup
 
       - name: Run tests
-        run: ./run_test.sh
+        run: cd backend-dashboard-2/ && ./run_test.sh
 
       - name: Send Discord message on failure
         if: ${{ failure() && ( inputs.environment == 'dev' || inputs.environment == 'main' ) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Run Tests
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_call:
+    inputs:
+      environment:
+        required: false
+        type: string
+
+jobs:
+  test-client:
+    runs-on: ubuntu-latest
+    name: Run React client tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Use client directory
+        run: cd client/
+
+      # Add React test suite setup
+
+      - name: Run tests
+        run: ./run_test.sh
+
+      - name: Send Discord message on failure
+        if: ${{ failure() && inputs.environment == 'production' }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ React Deployment Tests Failed"
+
+  test-server:
+    runs-on: ubuntu-latest
+    name: Run Ruby server tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Use client directory
+        run: cd backend-dashboard-2/
+
+      # Add Rails test suite setup
+
+      - name: Run tests
+        run: ./run_test.sh
+
+      - name: Send Discord message on failure
+        if: ${{ failure() && inputs.environment == 'production' }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ Rails Deployment Tests Failed"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
         run: ./run_test.sh
 
       - name: Send Discord message on failure
-        if: ${{ failure() && inputs.environment == 'production' }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ React Deployment Tests Failed"
+        if: ${{ failure() && ( inputs.environment == 'development' || inputs.environment == 'production' ) }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ React tests for ${{ inputs.environment }} deployment failed"
 
   test-server:
     runs-on: ubuntu-latest
@@ -46,6 +46,5 @@ jobs:
         run: ./run_test.sh
 
       - name: Send Discord message on failure
-        if: ${{ failure() && inputs.environment == 'production' }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ Rails Deployment Tests Failed"
-
+        if: ${{ failure() && ( inputs.environment == 'development' || inputs.environment == 'production' ) }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ Rails tests for ${{ inputs.environment }} deployment failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
         run: ./run_test.sh
 
       - name: Send Discord message on failure
-        if: ${{ failure() && ( inputs.environment == 'development' || inputs.environment == 'production' ) }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ React tests for ${{ inputs.environment }} deployment failed"
+        if: ${{ failure() && ( inputs.environment == 'dev' || inputs.environment == 'main' ) }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ React tests for \`${{ inputs.environment }}\` deployment failed"
 
   test-server:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,5 +46,5 @@ jobs:
         run: ./run_test.sh
 
       - name: Send Discord message on failure
-        if: ${{ failure() && ( inputs.environment == 'development' || inputs.environment == 'production' ) }}
-        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ Rails tests for ${{ inputs.environment }} deployment failed"
+        if: ${{ failure() && ( inputs.environment == 'dev' || inputs.environment == 'main' ) }}
+        run: curl -s -X POST "${{ secrets.DISCORD_WEBHOOK }}" -d "content=⚠️ Rails tests for \`${{ inputs.environment }}\` deployment failed"

--- a/backend-dashboard-2/redeploy.sh
+++ b/backend-dashboard-2/redeploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+tmux kill-session -t server
+tmux new-session -d -s server
+tmux send-keys -t server 'bundle install' C-m
+tmux send-keys -t server 'bin/rails server -b 0.0.0.0' C-m
+tmux detach -s server

--- a/backend-dashboard-2/run_test.sh
+++ b/backend-dashboard-2/run_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "No Rails tests have been set up"

--- a/client/redeploy.sh
+++ b/client/redeploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+tmux kill-session -t client
+tmux new-session -d -s client
+tmux send-keys -t client 'npm install' C-m
+tmux send-keys -t client 'npm run build' C-m
+tmux send-keys -t client 'cd dist/' C-m
+tmux send-keys -t client 'http-server --cors' C-m
+tmux detach -s client

--- a/client/run_test.sh
+++ b/client/run_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "No React tests have been set up"


### PR DESCRIPTION
- Workflow `test.yml`
    - is performed on pull request to `main` and `dev`
    - requires Action secret `DISCORD_WEBHOOK` to send notifications
- Workflow `deploy-dev.yml`
    - is performed on commit to `dev`
    - calls `test.yml` and sends notification on failure
    - deploys onto VPS
    - requires Action secrets
        - `PROJECT_ROOT`: where the repo is located in the VPS filesystem
        - `DISCORD_WEBHOOK`: see above
        - `DEV_SSH_IP`: VPS IP address
        - `DEV_SSH_USER`: username to log in to VPS
        - `DEV_SSH_PRIVATE_KEY`: private key of SSH pair that has already been authorized in the VPS (instructions at the bottom)
- Workflow `deploy-main.yml`
    - is performed on commit to `main`
    - does the same thing as `deploy-dev.yml`
    - SSH Action secrets start with `MAIN` rather than `DEV`

**Setting up **
```bash
ssh-keygen # take note of the key file name
ssh-copy-id -i <KEY_FILE_NAME>.pub <USER>@<IP>
cat ~/.ssh/<KEY_FILE_NAME> # copy the output of this and enter as private key secret
```