### PR TITLE
Implement certificates endpoint filtering by type and my team

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Using your MongoDB manager or provider create a database for the IBM SkillBoard 
   - `GET /api/v1/users`: Fetch all users
   - `GET /api/v1/users/:id`: Fetch user info
 - [Certificates](#certificates)
-  - `GET /api/v1/certificates`: Fetch all certificates and also filtered by type and in the user's teams
-  - `GET /api/v1/certificates/:id`: Fetch certificate info
+  - `GET /api/v1/certificates`: Fetch all certificates
+  - `GET /api/v1/certificates/:type`: Fetch certificate filtered by type (`all`, `ibm`, `industry`, `my_teams`)
 - [Categories](#categories)
   - `GET /api/v1/categories`: Fetch all registered categories
   - `GET /api/v1/categories/:id`: Fetch category 
@@ -183,19 +183,6 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
 
 
 - `GET /api/v1/certificates`: Fetch all certificates
-    - Optional JSON body parameters
-        ```json
-        {
-            "type": "industry",
-            "my_teams": ""
-        }
-        ```
-        - Endpoint is dynamic, it can receive:
-            - No JSON parameters; returns all certificates
-            - `type` only; returns all certificates of `type`
-            - `my_teams` only; returns all certificates people in the logged user's team have
-            - Both `type` and `my_teams`; returns all certificates people in the logged user's teams have that are of `type`
-        - **Only presence on `my_teams` is evaluated**, therefore an empty string still enables filtering
     - Response
         ```json
         Status: 200 OK
@@ -219,25 +206,29 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
                 ...
             ]
         ```
-- `GET /api/v1/certificates/:id`: Fetch certificate info
+- `GET /api/v1/certificates/:type`: Fetch certificates by type
+    - Types: `all`, `ibm`, `industry`, `my_teams`
     - Response
         ```json
         JSON body:
-            {
-                "certificate": {
-                    "id": "643efe1cd2f1c148b579fd74"
-                    "name": "Watson Specialist v1",
-                    "type": "ibm",
-                    "expiration_date": "2025-07-05"
-                },
-                "categories": [
-                    {
-                        "id": "644c95d4d2f1c175be910954",
-                        "name": "AI"
+            [
+                {
+                    "certificate": {
+                        "id": "643efe1cd2f1c148b579fd74"
+                        "name": "Watson Specialist v1",
+                        "type": "ibm",
+                        "expiration_date": "2025-07-05"
                     },
-                    ...
-                ]
-            }
+                    "categories": [
+                        {
+                            "id": "644c95d4d2f1c175be910954",
+                            "name": "AI"
+                        },
+                        ...
+                    ]
+                },
+                ...
+            ]
         ```
 ### Categories
 - `GET /api/v1/categories`: Fetch categories

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Using your MongoDB manager or provider create a database for the IBM SkillBoard 
   - `GET /api/v1/users`: Fetch all users
   - `GET /api/v1/users/:id`: Fetch user info
 - [Certificates](#certificates)
-  - `GET /api/v1/certificates`: Fetch all certificates and also filtered by type
+  - `GET /api/v1/certificates`: Fetch all certificates and also filtered by type and in the user's teams
   - `GET /api/v1/certificates/:id`: Fetch certificate info
 - [Categories](#categories)
   - `GET /api/v1/categories`: Fetch all registered categories
@@ -186,9 +186,11 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
     - Optional JSON body parameters
         ```json
         {
-            "type": "industry"
+            "type": "industry",
+            "my_teams": ""
         }
         ```
+        - Sending `my_teams` returns certificates employees in any of the teams the logged in user is a member of (as employee or manager), only presence is evaluated, therefore an empty string would still enable filtering
     - Response
         ```json
         Status: 200 OK

--- a/README.md
+++ b/README.md
@@ -202,12 +202,19 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
         JSON body:
             [
                 {
-                    "_id": { "$oid": "643efe1cd2f1c148b579fd74" },
-                    "name": "Watson Specialist v1",
-                    "type": "ibm",
-                    "expiration_date": "2024-04-01",
-                    "created_at": "2023-04-18T20:31:24.184Z",
-                    "updated_at": "2023-04-18T20:31:24.184Z"
+                    "certificate": {
+                        "id": "643efe1cd2f1c148b579fd74"
+                        "name": "Watson Specialist v1",
+                        "type": "ibm",
+                        "expiration_date": "2025-07-05"
+                    },
+                    "categories": [
+                        {
+                            "id": "644c95d4d2f1c175be910954",
+                            "name": "AI"
+                        },
+                        ...
+                    ]
                 },
                 ...
             ]
@@ -217,12 +224,19 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
         ```json
         JSON body:
             {
-                "_id": { "$oid": "643efe1cd2f1c148b579fd74" },
-                "name": "Watson Specialist v1",
-                "type": "ibm",
-                "expiration_date": "2024-04-01",
-                "created_at": "2023-04-18T20:31:24.184Z",
-                "updated_at": "2023-04-18T20:31:24.184Z"
+                "certificate": {
+                    "id": "643efe1cd2f1c148b579fd74"
+                    "name": "Watson Specialist v1",
+                    "type": "ibm",
+                    "expiration_date": "2025-07-05"
+                },
+                "categories": [
+                    {
+                        "id": "644c95d4d2f1c175be910954",
+                        "name": "AI"
+                    },
+                    ...
+                ]
             }
         ```
 ### Categories

--- a/README.md
+++ b/README.md
@@ -190,7 +190,12 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
             "my_teams": ""
         }
         ```
-        - Sending `my_teams` returns certificates employees in any of the teams the logged in user is a member of (as employee or manager), only presence is evaluated, therefore an empty string would still enable filtering
+        - Endpoint is dynamic, it can receive:
+            - No JSON parameters
+            - `type` only
+            - `my_teams` only
+            - Both `type` and `my_teams`
+        - Sending `my_teams` returns certificates employees in any of the teams the logged in user is a member of (as employee or manager), **only presence is evaluated**, therefore an empty string would still enable filtering
     - Response
         ```json
         Status: 200 OK

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Using your MongoDB manager or provider create a database for the IBM SkillBoard 
   - `GET /api/v1/users`: Fetch all users
   - `GET /api/v1/users/:id`: Fetch user info
 - [Certificates](#certificates)
-  - `GET /api/v1/certificates`: Fetch all certificates
+  - `GET /api/v1/certificates`: Fetch all certificates and also filtered by type
   - `GET /api/v1/certificates/:id`: Fetch certificate info
 - [Categories](#categories)
   - `GET /api/v1/categories`: Fetch all registered categories
@@ -183,6 +183,12 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
 
 
 - `GET /api/v1/certificates`: Fetch all certificates
+    - Optional JSON body parameters
+        ```json
+        {
+            "type": "industry"
+        }
+        ```
     - Response
         ```json
         Status: 200 OK

--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ Note: if an endpoint is not listed here, a complete list can be retrieved by run
         }
         ```
         - Endpoint is dynamic, it can receive:
-            - No JSON parameters
-            - `type` only
-            - `my_teams` only
-            - Both `type` and `my_teams`
-        - Sending `my_teams` returns certificates employees in any of the teams the logged in user is a member of (as employee or manager), **only presence is evaluated**, therefore an empty string would still enable filtering
+            - No JSON parameters; returns all certificates
+            - `type` only; returns all certificates of `type`
+            - `my_teams` only; returns all certificates people in the logged user's team have
+            - Both `type` and `my_teams`; returns all certificates people in the logged user's teams have that are of `type`
+        - **Only presence on `my_teams` is evaluated**, therefore an empty string still enables filtering
     - Response
         ```json
         Status: 200 OK

--- a/server/app/controllers/api/v1/certificates_controller.rb
+++ b/server/app/controllers/api/v1/certificates_controller.rb
@@ -4,10 +4,14 @@ class Api::V1::CertificatesController < ApplicationController
 
     # GET /certificates
     def index
-      if !params[:type]
-        @certificates = Certificate.all
-      else
-        @certificates = Certificate.where(type: params[:type])
+      @certificates = Certificate.all
+
+      if params[:type]
+        if params[:type] != "ibm" && params[:type] != "industry"
+          render json: { error: "type must be either ibm or industry" }, status: :bad_request
+          return
+        end
+        @certificates = @certificates.where(type: params[:type])
       end
   
       render json: @certificates

--- a/server/app/controllers/api/v1/certificates_controller.rb
+++ b/server/app/controllers/api/v1/certificates_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::CertificatesController < ApplicationController
   
     # GET /certificates/1
     def show
-      render json: @certificates.map { |certificate| certificate.all_info }
+      render json: @certificate.all_info
     end
   
     # POST /certificates

--- a/server/app/controllers/api/v1/certificates_controller.rb
+++ b/server/app/controllers/api/v1/certificates_controller.rb
@@ -4,7 +4,11 @@ class Api::V1::CertificatesController < ApplicationController
 
     # GET /certificates
     def index
-      @certificates = Certificate.all
+      if !params[:type]
+        @certificates = Certificate.all
+      else
+        @certificates = Certificate.where(type: params[:type])
+      end
   
       render json: @certificates
     end

--- a/server/app/controllers/api/v1/certificates_controller.rb
+++ b/server/app/controllers/api/v1/certificates_controller.rb
@@ -33,12 +33,12 @@ class Api::V1::CertificatesController < ApplicationController
         @certificates = @certificates.where(type: params[:type])
       end
   
-      render json: @certificates
+      render json: @certificates.map { |certificate| certificate.all_info }
     end
   
     # GET /certificates/1
     def show
-      render json: @certificates
+      render json: @certificates.map { |certificate| certificate.all_info }
     end
   
     # POST /certificates

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -34,4 +34,11 @@ class Certificate
     categories.map { |category| category.info }
   end
 
+  def all_info
+    {
+      certificate: self.info,
+      categories: self.categories,
+    }
+  end
+
 end

--- a/server/app/models/employee.rb
+++ b/server/app/models/employee.rb
@@ -33,7 +33,7 @@ class Employee
 
   def certificates
     certificates = Certificate.where(:_id.in => (certificate_employees.pluck(:certificate_id)))
-    certificates.map { |certificate| { certificate: certificate.info, categories: certificate.categories } }
+    certificates.map { |certificate| certificate.all_info }
   end
 
   field :_id, type: String, default: ->{BSON::ObjectId.new.to_s}


### PR DESCRIPTION
Endpoint `/api/v1/certificates/:type` returns list of certificates filtered by `type`: `all`, `ibm`, `industry`, `my_teams`

This pull request also includes documentation