### PR TITLE
Mass certificates addition

### DIFF
--- a/server/app/controllers/api/v1/certificates_controller.rb
+++ b/server/app/controllers/api/v1/certificates_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::CertificatesController < ApplicationController
   
     # POST /certificates
     def create
-      @certificate = Certificate.new(name: params[:name], expiration_date: params[:expiration_date], type: params[:type])
+      @certificate = Certificate.new(name: params[:name],issue_date: params[:issue_date], expiration_date: params[:expiration_date], type: params[:type])
   
       if @certificate.save
         render json: @certificate, status: :created, location: api_v1_certificate_url(@certificate)
@@ -53,6 +53,15 @@ class Api::V1::CertificatesController < ApplicationController
       end
       
     end
+
+    def mass_create
+      statuses = []
+      params[:certificates].each do |certificate_params|
+         @certificate = Certificate.new(name: certificate_params[:name], issue_date: certificate_params[:issue_date], expiration_date: certificate_params[:expiration_date], type: certificate_params[:type])
+         statuses << ( @certificate.save ? "OK" : @certificate.errors )
+    end if params[:certificates]
+      render json: statuses
+    end   
   
     # PATCH/PUT /certificates/1
     def update
@@ -76,6 +85,6 @@ class Api::V1::CertificatesController < ApplicationController
   
       # Only allow a list of trusted parameters through.
       def certificate_params
-        params.fetch(:certificate).permit(:name, :expiration_date, :type)
+        params.fetch(:certificate).permit(:name, :issue_date, :expiration_date, :type)
       end
 end

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -4,6 +4,7 @@ class Certificate
 
   field :name, type: String
   field :type, type: String
+  field :issue_date, type: Date
   field :expiration_date, type: Date
 
   has_many :certificate_employees, class_name: 'CertificateEmployee', foreign_key: 'certificate_id'
@@ -25,6 +26,7 @@ class Certificate
       id: self._id.to_s,
       name: self.name,
       type: self.type,
+      issue_date: self.issue_date,
       expiration_date: self.expiration_date,
     }
   end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -3,8 +3,12 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users
-      resources :employees
-      resources :certificates
+      resources :employees do
+        get "viewer", on: :collection
+      end
+      resources :certificates do
+        post 'mass_create', on: :collection
+      end
       resources :manager_teams
       resources :employee_teams
       resources :teams
@@ -14,7 +18,6 @@ Rails.application.routes.draw do
 
       post "login", to: "auth#login"
       post "logout", to: "auth#logout"
-      get "viewer", to: "employees#viewer"
 
       end
   end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :users
       resources :employees do
         get "viewer", on: :collection
+        get "myteamviewer", on: :collection
       end
       resources :certificates do
         post 'mass_create', on: :collection


### PR DESCRIPTION
Mass Certificate Addition feature added to add multiple JSON on the endpoint in this format:
```JSON

{
    "certificates":
    [
        {
            "name": "Badge - Global Sales School",
            "issue_date": "2019-08-22",
            "expiration_date": "null",
            "type": "ibm"
        },
        {
            "name": "Badge - Faculty Academy Instructor",
            "issue_date": "2017-10-18",
            "expiration_date": "null",
            "type": "ibm"
        },
        {
            "name": "Badge - Enterprise Design Thinking Practitioner",
            "issue_date": "2017-07-12",
            "expiration_date": "null",
            "type": "ibm"
        },
    ]
}
```
`POST   /api/v1/certificates/mass_create(.:format)`

Changes made on model and controller to add an `issue_date` to parameters