### PR TITLE
(backend) /employees returns in same format as /employees/id

### DIFF
--- a/server/app/controllers/api/v1/employees_controller.rb
+++ b/server/app/controllers/api/v1/employees_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::EmployeesController < ApplicationController
 
   # GET /employees
   def index
-    @employees = Employee.all
+    @employees = Employee.all.each { |employee| { employee: @employee.info, teams: @employee.teams, certificates: @employee.certificates } }
 
     render json: @employees
   end

--- a/server/app/controllers/api/v1/employees_controller.rb
+++ b/server/app/controllers/api/v1/employees_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::EmployeesController < ApplicationController
 
   # GET /employees
   def index
-    @employees = Employee.all.each { |employee| { employee: @employee.info, teams: @employee.teams, certificates: @employee.certificates } }
+    @employees = Employee.all.map { |employee| { employee: @employee.info, teams: @employee.teams, certificates: @employee.certificates } }
 
     render json: @employees
   end


### PR DESCRIPTION
`/employees` endpoint returns list of objects in the same structure as `/employees/id`: 

```json
{
  "employee": {},
  "teams": [],
  "certificates": []
}
```